### PR TITLE
Suppress PTEX info in vignette for reproducibility.

### DIFF
--- a/vignettes/R.devices-overview.tex.rsp
+++ b/vignettes/R.devices-overview.tex.rsp
@@ -83,6 +83,8 @@ options(str=strOptions(strict.width="cut"))
 \author{<%@meta name="author"%>}
 \date{<%=format(as.Date(R.devices$date), format="%B %d, %Y")%>}
 
+\pdfsuppressptexinfo=-1
+
 \begin{document}
 
 \maketitle


### PR DESCRIPTION
Otherwise, we get PTEX.FileName metadata for an included figure containing the build path.